### PR TITLE
Add redux config

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@reduxjs/toolkit": "^1.7.1",
     "@testing-library/jest-dom": "^5.14.1",
     "@testing-library/react": "^12.0.0",
     "@testing-library/user-event": "^13.2.1",
@@ -12,8 +13,10 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-jss": "^10.9.0",
+    "react-redux": "^7.2.6",
     "react-router-dom": "^6.2.1",
     "react-scripts": "5.0.0",
+    "redux": "^4.1.2",
     "web-vitals": "^2.1.0"
   },
   "scripts": {

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,12 +1,16 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
+import { Provider } from 'react-redux';
 import './index.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
+import { store } from './store';
 
 ReactDOM.render(
   <React.StrictMode>
-    <App />
+    <Provider store={store}>
+      <App />
+    </Provider>
   </React.StrictMode>,
   document.getElementById('root')
 );

--- a/src/lib/prop-types.js
+++ b/src/lib/prop-types.js
@@ -7,7 +7,7 @@ export const forecastPropType = PropTypes.shape({
     tempMin: PropTypes.number,
   }).isRequired,
   summary: PropTypes.string.isRequired,
-  time: PropTypes.instanceOf(Date).isRequired,
+  time: PropTypes.number.isRequired,
 });
 
 export default {

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -1,0 +1,7 @@
+/* eslint-disable import/prefer-default-export */
+import { configureStore } from '@reduxjs/toolkit';
+import rootReducer from './modules';
+
+export const store = configureStore({
+  reducer: rootReducer,
+});

--- a/src/store/modules/index.js
+++ b/src/store/modules/index.js
@@ -1,0 +1,8 @@
+import { combineReducers } from 'redux';
+import selection from './selection/selectionSlice';
+
+const rootReducer = combineReducers({
+  selection,
+});
+
+export default rootReducer;

--- a/src/store/modules/selection/selectionSlice.js
+++ b/src/store/modules/selection/selectionSlice.js
@@ -1,0 +1,20 @@
+/* eslint-disable no-param-reassign */
+import { createSlice } from '@reduxjs/toolkit';
+
+const initialState = {
+  forecast: undefined,
+};
+
+const selectionSlice = createSlice({
+  name: 'selection',
+  initialState,
+  reducers: {
+    updateForecastSelection: (state, action) => {
+      state.forecast = action.payload;
+    },
+  },
+});
+
+export const { updateForecastSelection } = selectionSlice.actions;
+
+export default selectionSlice.reducer;

--- a/src/views/Forecast.jsx
+++ b/src/views/Forecast.jsx
@@ -1,7 +1,9 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { createUseStyles } from 'react-jss';
+import { useDispatch, useSelector } from 'react-redux';
 import Card from '../components/Forecast/Card';
 import Selection from '../components/Forecast/Selection';
+import { updateForecastSelection } from '../store/modules/selection/selectionSlice';
 
 const FORECAST_DATA = [
   {
@@ -11,7 +13,7 @@ const FORECAST_DATA = [
       tempMax: 12,
     },
     summary: 'Clouds',
-    time: new Date(2021, 2, 28, 0, 0),
+    time: new Date(2021, 2, 28, 0, 0).getTime(),
   },
   {
     measurements: {
@@ -20,7 +22,7 @@ const FORECAST_DATA = [
       tempMax: 12,
     },
     summary: 'Clouds',
-    time: new Date(2021, 2, 28, 1, 0),
+    time: new Date(2021, 2, 28, 1, 0).getTime(),
   },
   {
     measurements: {
@@ -29,7 +31,7 @@ const FORECAST_DATA = [
       tempMax: 12,
     },
     summary: 'Clouds',
-    time: new Date(2021, 2, 28, 2, 0),
+    time: new Date(2021, 2, 28, 2, 0).getTime(),
   },
   {
     measurements: {
@@ -38,7 +40,7 @@ const FORECAST_DATA = [
       tempMax: 12,
     },
     summary: 'Clouds',
-    time: new Date(2021, 2, 28, 3, 0),
+    time: new Date(2021, 2, 28, 3, 0).getTime(),
   },
   {
     measurements: {
@@ -47,7 +49,7 @@ const FORECAST_DATA = [
       tempMax: 12,
     },
     summary: 'Clouds',
-    time: new Date(2021, 2, 28, 4, 0),
+    time: new Date(2021, 2, 28, 4, 0).getTime(),
   },
   {
     measurements: {
@@ -56,7 +58,7 @@ const FORECAST_DATA = [
       tempMax: 12,
     },
     summary: 'Clear',
-    time: new Date(2021, 2, 28, 5, 0),
+    time: new Date(2021, 2, 28, 5, 0).getTime(),
   },
   {
     measurements: {
@@ -65,7 +67,7 @@ const FORECAST_DATA = [
       tempMax: 12,
     },
     summary: 'Clear',
-    time: new Date(2021, 2, 28, 6, 0),
+    time: new Date(2021, 2, 28, 6, 0).getTime(),
   },
   {
     measurements: {
@@ -74,7 +76,7 @@ const FORECAST_DATA = [
       tempMax: 12,
     },
     summary: 'Clear',
-    time: new Date(2021, 2, 28, 7, 0),
+    time: new Date(2021, 2, 28, 7, 0).getTime(),
   },
 ];
 
@@ -89,14 +91,20 @@ const useStyles = createUseStyles({
 });
 
 const Forecast = function Forecast() {
+  const dispatch = useDispatch();
   const classes = useStyles();
+  const selectedForecast = useSelector((state) => state.selection.forecast);
+
+  useEffect(() => {
+    dispatch(updateForecastSelection(FORECAST_DATA[0]));
+  }, [dispatch]);
 
   return (
     <main className={classes.mainContainer}>
-      <Selection forecast={FORECAST_DATA[0]} />
+      {selectedForecast && <Selection forecast={selectedForecast} />}
       <section className={classes.cardsContainer}>
         {FORECAST_DATA.map((forecast) => (
-          <Card key={forecast.time.getTime()} forecast={forecast} />
+          <Card key={forecast.time} forecast={forecast} />
         ))}
       </section>
     </main>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1021,7 +1021,7 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.3.1", "@babel/runtime@^7.8.3":
+"@babel/runtime@^7.15.4", "@babel/runtime@^7.3.1", "@babel/runtime@^7.8.3":
   version "7.16.7"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.16.7.tgz#03ff99f64106588c9c403c6ecb8c3bafbbdff1fa"
   integrity sha512-9E9FJowqAsytyOY6LG+1KuueckRL+aQW+mKvXRXnuFGyRAyepJPmEo9vgMfXUA6O9u3IeEdv9MAkppFcaQwogQ==
@@ -1332,6 +1332,16 @@
     loader-utils "^2.0.0"
     schema-utils "^3.0.0"
     source-map "^0.7.3"
+
+"@reduxjs/toolkit@^1.7.1":
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/@reduxjs/toolkit/-/toolkit-1.7.1.tgz#994962aeb7df3c77be343dd2ad1aa48221dbaa0c"
+  integrity sha512-wXwXYjBVz/ItxB7SMzEAMmEE/FBiY1ze18N+VVVX7NtVbRUrdOGKhpQMHivIJfkbJvSdLUU923a/yAagJQzY0Q==
+  dependencies:
+    immer "^9.0.7"
+    redux "^4.1.2"
+    redux-thunk "^2.4.1"
+    reselect "^4.1.5"
 
 "@rollup/plugin-babel@^5.2.0":
   version "5.3.0"
@@ -1684,6 +1694,14 @@
   dependencies:
     "@types/node" "*"
 
+"@types/hoist-non-react-statics@^3.3.0":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz#1124aafe5118cb591977aeb1ceaaed1070eb039f"
+  integrity sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==
+  dependencies:
+    "@types/react" "*"
+    hoist-non-react-statics "^3.3.0"
+
 "@types/html-minifier-terser@^6.0.0":
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/@types/html-minifier-terser/-/html-minifier-terser-6.1.0.tgz#4fc33a00c1d0c16987b1a20cf92d20614c55ac35"
@@ -1753,6 +1771,11 @@
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.4.2.tgz#4c62fae93eb479660c3bd93f9d24d561597a8281"
   integrity sha512-ekoj4qOQYp7CvjX8ZDBgN86w3MqQhLE1hczEJbEIjgFEumDy+na/4AJAbLXfgEWFNB2pKadM5rPFtuSGMWK7xA==
 
+"@types/prop-types@*":
+  version "15.7.4"
+  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.4.tgz#fcf7205c25dff795ee79af1e30da2c9790808f11"
+  integrity sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ==
+
 "@types/q@^1.5.1":
   version "1.5.5"
   resolved "https://registry.yarnpkg.com/@types/q/-/q-1.5.5.tgz#75a2a8e7d8ab4b230414505d92335d1dcb53a6df"
@@ -1768,6 +1791,25 @@
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.4.tgz#cd667bcfdd025213aafb7ca5915a932590acdcdc"
   integrity sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==
 
+"@types/react-redux@^7.1.20":
+  version "7.1.21"
+  resolved "https://registry.yarnpkg.com/@types/react-redux/-/react-redux-7.1.21.tgz#f32bbaf7cbc4b93f51e10d340aa54035c084b186"
+  integrity sha512-bLdglUiBSQNzWVVbmNPKGYYjrzp3/YDPwfOH3nLEz99I4awLlaRAPWjo6bZ2POpxztFWtDDXIPxBLVykXqBt+w==
+  dependencies:
+    "@types/hoist-non-react-statics" "^3.3.0"
+    "@types/react" "*"
+    hoist-non-react-statics "^3.3.0"
+    redux "^4.0.0"
+
+"@types/react@*":
+  version "17.0.38"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.38.tgz#f24249fefd89357d5fa71f739a686b8d7c7202bd"
+  integrity sha512-SI92X1IA+FMnP3qM5m4QReluXzhcmovhZnLNm3pyeQlooi02qI7sLiepEYqT678uNiyc25XfCqxREFpy3W7YhQ==
+  dependencies:
+    "@types/prop-types" "*"
+    "@types/scheduler" "*"
+    csstype "^3.0.2"
+
 "@types/resolve@1.17.1":
   version "1.17.1"
   resolved "https://registry.yarnpkg.com/@types/resolve/-/resolve-1.17.1.tgz#3afd6ad8967c77e4376c598a82ddd58f46ec45d6"
@@ -1779,6 +1821,11 @@
   version "0.12.1"
   resolved "https://registry.yarnpkg.com/@types/retry/-/retry-0.12.1.tgz#d8f1c0d0dc23afad6dc16a9e993a0865774b4065"
   integrity sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g==
+
+"@types/scheduler@*":
+  version "0.16.2"
+  resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.2.tgz#1a62f89525723dde24ba1b01b092bf5df8ad4d39"
+  integrity sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==
 
 "@types/serve-index@^1.9.1":
   version "1.9.1"
@@ -4457,7 +4504,7 @@ history@^5.2.0:
   dependencies:
     "@babel/runtime" "^7.7.6"
 
-hoist-non-react-statics@^3.2.0, hoist-non-react-statics@^3.3.0:
+hoist-non-react-statics@^3.2.0, hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
@@ -7209,7 +7256,7 @@ react-is@^16.13.1, react-is@^16.7.0, react-is@^16.8.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
-react-is@^17.0.1:
+react-is@^17.0.1, react-is@^17.0.2:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
@@ -7230,6 +7277,18 @@ react-jss@^10.9.0:
     shallow-equal "^1.2.0"
     theming "^3.3.0"
     tiny-warning "^1.0.2"
+
+react-redux@^7.2.6:
+  version "7.2.6"
+  resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-7.2.6.tgz#49633a24fe552b5f9caf58feb8a138936ddfe9aa"
+  integrity sha512-10RPdsz0UUrRL1NZE0ejTkucnclYSgXp5q+tB5SWx2qeG2ZJQJyymgAhwKy73yiL/13btfB6fPr+rgbMAaZIAQ==
+  dependencies:
+    "@babel/runtime" "^7.15.4"
+    "@types/react-redux" "^7.1.20"
+    hoist-non-react-statics "^3.3.2"
+    loose-envify "^1.4.0"
+    prop-types "^15.7.2"
+    react-is "^17.0.2"
 
 react-refresh@^0.11.0:
   version "0.11.0"
@@ -7358,6 +7417,18 @@ redent@^3.0.0:
     indent-string "^4.0.0"
     strip-indent "^3.0.0"
 
+redux-thunk@^2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.4.1.tgz#0dd8042cf47868f4b29699941de03c9301a75714"
+  integrity sha512-OOYGNY5Jy2TWvTL1KgAlVy6dcx3siPJ1wTq741EPyUKfn6W6nChdICjZwCd0p8AZBs5kWpZlbkXW2nE/zjUa+Q==
+
+redux@^4.0.0, redux@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/redux/-/redux-4.1.2.tgz#140f35426d99bb4729af760afcf79eaaac407104"
+  integrity sha512-SH8PglcebESbd/shgf6mii6EIoRM0zrQyjcuQ+ojmfxjTtE0z9Y8pa62iA/OJ58qjP6j27uyW4kUF4jl/jd6sw==
+  dependencies:
+    "@babel/runtime" "^7.9.2"
+
 regenerate-unicode-properties@^9.0.0:
   version "9.0.0"
   resolved "https://registry.yarnpkg.com/regenerate-unicode-properties/-/regenerate-unicode-properties-9.0.0.tgz#54d09c7115e1f53dc2314a974b32c1c344efe326"
@@ -7454,6 +7525,11 @@ requires-port@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
   integrity sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=
+
+reselect@^4.1.5:
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/reselect/-/reselect-4.1.5.tgz#852c361247198da6756d07d9296c2b51eddb79f6"
+  integrity sha512-uVdlz8J7OO+ASpBYoz1Zypgx0KasCY20H+N8JD13oUMtPvSHQuscrHop4KbXrbsBcdB9Ds7lVK7eRkBIfO43vQ==
 
 resolve-cwd@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
Closes #4

This PR adds global state configuration to the SPA, using the following packages:
- `redux`
- `@reduxjs/toolkit`
- `react-redux`

The reason for using Redux and Redux Toolkit to manage the global state is because there are 2 parts of the state needed for the application to work:
- Data that needs to be fetched from the [OpenWeatherMap 5 day weather forecast API](https://openweathermap.org/forecast5), in a simple way. This will be accomplished with [RTK Query](https://redux-toolkit.js.org/rtk-query/overview), which also allows an easier access later
- Selection of a particular time forecast, performed by the user, which in turns should display the details of the selected time forecast as the main information

At first, this PR was not meant to include anything else than Redux configuration. However, since it was better to test this configuration, a Redux slice for the forecast selection was added as well. At the moment, it only sets the state with a static forecast selection, and the update of this selection triggered by the user will be addressed in a following PR.
